### PR TITLE
Add Node-Red into fadi

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -76,3 +76,7 @@ dependencies:
   version: ^0.1.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: nginx_ldapauth_proxy.enabled
+- name: node-red
+  version: ^1.4.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: node-red.enabled

--- a/values.yaml
+++ b/values.yaml
@@ -314,6 +314,7 @@ openldap:
   customLdifFiles:
     1-default-users.ldif: |-
       # You can find an example ldif file.
+
 phpldapadmin:
   enabled: true
   service:
@@ -416,3 +417,22 @@ swaggerui:
     path: /
     hosts: [swagger-tsimulus.fadi.minikube]
     tls: []
+
+node-red:
+  enabled: true
+  service:
+    type: NodePort
+    port: 1880
+    nodePort: 31880
+  ingress:
+    enabled: false
+    annotations: {}
+    path: /
+    hosts:
+      - chart-example.local
+    tls: []
+  persistence:
+    enabled: true
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 5Gi

--- a/values.yaml
+++ b/values.yaml
@@ -419,7 +419,7 @@ swaggerui:
     tls: []
 
 node-red:
-  enabled: true
+  enabled: false
   service:
     type: NodePort
     port: 1880


### PR DESCRIPTION
Add node-red tool into the FADI with the following defaults values:

- ServiceType : NodePort  ( port 1880 -> 31880)
- No ingress
- Persistent data ( 5Go Read-write)