### PR TITLE
Upgrade Nifi chart to ~0.5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: fadi
-version: 0.2.4
-appVersion: 0.2.4
+version: 0.2.5
+appVersion: 0.2.5
 description: FADI is a Cloud Native platform for Big Data based on mature open source tools. 
 keywords:
   - fadi
@@ -47,7 +47,7 @@ dependencies:
   repository: https://jupyterhub.github.io/helm-chart/
   condition: jupyterhub.enabled
 - name: nifi
-  version: ~0.4.2
+  version: ~0.5.4
   repository: https://cetic.github.io/helm-charts/
   condition: nifi.enabled
 - name: openldap


### PR DESCRIPTION
#### What this PR does / why we need it:

Use the newer ~0.5 versions of the Nifi chart.

#### Special notes for your reviewer:

Tested on minikube v1.13.1, kvm, helm v3.0.2, kubernetes v1.19.2
