### PR TITLE
Update pg-ldap-sync cron job frequency

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: fadi
-version: 0.2.6
-appVersion: 0.2.6
+version: 0.2.7
+appVersion: 0.2.7
 description: FADI is a Cloud Native platform for Big Data based on mature open source tools. 
 keywords:
   - fadi

--- a/values.yaml
+++ b/values.yaml
@@ -115,7 +115,7 @@ postgresql:
         create_options: NOLOGIN IN ROLE ldap_groups
         #grant_options:
     cron:
-      schedule: "*/1 * * * *"
+      schedule: "*/30 * * * *"
       repo: ceticasbl/pg-ldap-sync
       tag: latest
       restartPolicy: Never


### PR DESCRIPTION
According to FADI newcomers feedback, the actual pg-ldap-sync cron job frequency (every 1 minute) is considered as a barrier to install FADI for the first time. 
They are usually facing a large list of failing and/or pending pods.
Therefore, I propose this PR to reduce the cron job frequency.