### PR TITLE
Adding an ingress with Traefik

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: fadi
-version: 0.2.12
-appVersion: 0.2.12
+version: 0.2.13
+appVersion: 0.2.13
 description: FADI is a Cloud Native platform for Big Data based on mature open source tools. 
 keywords:
   - fadi

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -131,3 +131,7 @@ dependencies:
   version: ^2.3.18
   repository: https://charts.bitnami.com/bitnami
   condition: influxdb.enabled
+- name: traefik
+  version: ~10.6.2
+  repository: https://helm.traefik.io/traefik
+  condition: traefik.enabled

--- a/templates/ingressroutes.yaml
+++ b/templates/ingressroutes.yaml
@@ -1,0 +1,28 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`grafana.test.local`) && PathPrefix(`/`)
+    services:
+    - name: fadi-grafana
+      port: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: nifi
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNI(`nifi.test.local`)
+    services:
+      - name: fadi-nifi
+        port: 9443
+  tls:
+    passthrough: true

--- a/templates/ingressroutes.yaml
+++ b/templates/ingressroutes.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.traefik.enabled -}}
+{{- if .Values.grafana.traefikIngress.enabled -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -7,11 +9,14 @@ spec:
     - web
   routes:
   - kind: Rule
-    match: Host(`grafana.test.local`) && PathPrefix(`/`)
+    match: Host(`{{ .Values.grafana.traefikIngress.host }}`) && PathPrefix(`/`)
     services:
-    - name: fadi-grafana
+    - name: {{ .Release.Name }}-grafana
       port: 80
+{{- end }}
 ---
+{{- if .Values.nifi.traefikIngress.enabled -}}
+{{- if .Values.nifi.properties.clusterSecure -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
@@ -20,9 +25,59 @@ spec:
   entryPoints:
     - websecure
   routes:
-  - match: HostSNI(`nifi.test.local`)
+  - match: HostSNI(`{{ .Values.nifi.traefikIngress.host }}`)
     services:
-      - name: fadi-nifi
-        port: 9443
+      - name: {{ .Release.Name }}-nifi
+        port: {{ .Values.nifi.properties.httpsPort }}
   tls:
     passthrough: true
+{{- else }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nifi
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`{{ .Values.nifi.traefikIngress.host }}`) && PathPrefix(`/`)
+    services:
+    - name: {{ .Release.Name }}-nifi
+      port: {{ .Values.nifi.properties.httpPort }}
+{{- end }}
+{{- end }}
+---
+{{- if .Values.jupyterhub.traefikIngress.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: hub
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`{{ .Values.jupyterhub.traefikIngress.host }}`) && PathPrefix(`/`)
+    services:
+    - name: hub
+      port: 8081
+{{- end }}
+---
+{{- if .Values.traefik.dashboardIngress.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`{{ .Values.traefik.dashboardHost }}`)
+      kind: Rule
+      services:
+        - name: api@internal
+          kind: TraefikService
+{{- end }}
+
+{{- end }}

--- a/templates/ingressroutes.yaml
+++ b/templates/ingressroutes.yaml
@@ -79,5 +79,21 @@ spec:
         - name: api@internal
           kind: TraefikService
 {{- end }}
+---
+{{- if .Values.superset.traefikIngress.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: superset
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`{{ .Values.superset.traefikIngress.host }}`) && PathPrefix(`/`)
+    services:
+    - name: {{ .Release.Name }}-superset
+      port: 9000
+{{- end }}
 
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -278,10 +278,10 @@ nifi:
     externalSecure: false
     isNode: true
     httpPort: 8080
-    httpsPort: 9443 #null
-    webProxyHost: nifi.test.local
+    httpsPort: #null
+    webProxyHost: # set it by the same host than nifi.traefikIngress.host if traefik ingress is enabled
     clusterPort: 6007
-    clusterSecure: true #false
+    clusterSecure: false
   auth:
     ldap:
       enabled: true
@@ -299,7 +299,7 @@ nifi:
 openldap:
   enabled: true
   persistence:
-    enabled: #true
+    enabled: true
   env:
     LDAP_ORGANISATION: "Cetic"
     LDAP_DOMAIN: "ldap.cetic.be"

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 # Declare variables to be passed into your templates.
 
 spark:
-  enabled: false
+  enabled: true
   Master:
     Name: spark-master
   WebUi:
@@ -16,7 +16,7 @@ spark:
     Replicas: 0
 
 superset:
-  enabled: false
+  enabled: true
   persistence:
     enabled: true
   service:
@@ -60,7 +60,7 @@ superset:
     AUTH_LDAP_UID_FIELD = "cn"
 
 postgresql:
-  enabled: false
+  enabled: true
   persistence:
     enabled: true
   ldap:
@@ -135,7 +135,7 @@ postgresql:
       psql -c "create database zabbix;" postgres admin
 
 minio:
-  enabled: false
+  enabled: true
   persistence:
     enabled: true
     size: 50Gi
@@ -167,7 +167,7 @@ grafana:
       config_file: /etc/grafana/ldap.toml
   # Enable persistence
   persistence:
-    enabled: false
+    enabled: true
   # Administrator credentials when not using an existing secret (see below)
   adminUser: admin
 
@@ -177,7 +177,7 @@ grafana:
   ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
   ## ref: http://docs.grafana.org/installation/ldap/#configuration
   ldap:
-    enabled: false
+    enabled: true
     # `existingSecret` is a reference to an existing secret containing the ldap configuration
     # for Grafana in a key `ldap-toml`.
     existingSecret: ""
@@ -210,9 +210,13 @@ grafana:
       username = "cn"
       member_of = "memberOf"
       email =  "email"
+  # ---- ingress ----
+  traefikIngress:
+    enabled: true
+    host: grafana.test.local
 
 jupyterhub:
-  enabled: false
+  enabled: true
   proxy:
     secretToken: 'af83775ec3bfaf0507ce596df51d491e7ed54450adc454038fa7405495465f19'
     db:
@@ -257,6 +261,10 @@ jupyterhub:
   prePuller:
     hook:
       enabled: false
+  # ---- ingress ----
+  traefikIngress:
+    enabled: true
+    host: hub.test.local
 
 nifi:
   enabled: true
@@ -265,7 +273,7 @@ nifi:
     nodePort: ""
   postStart: /opt/nifi/psql; wget -P /opt/nifi/psql https://jdbc.postgresql.org/download/postgresql-42.2.6.jar
   persistence:
-    enabled: false
+    enabled: true
   properties:
     externalSecure: false
     isNode: true
@@ -277,20 +285,21 @@ nifi:
   auth:
     ldap:
       enabled: true
-      host: ldap://fadi-openldap:389 #ldap://<hostname>:<port>
-      searchBase: cn=admin,dc=ldap,dc=cetic,dc=be #CN=admin,DC=ldap,DC=example,DC=be
-      admin: cn=admin,dc=ldap,dc=cetic,dc=be #cn=admin,dc=ldap,dc=example,dc=be
-      pass: Z2JHHezi4aCC #ChangeMe
+      host: #ldap://<hostname>:<port>
+      searchBase: #CN=admin,DC=ldap,DC=example,DC=be
+      admin: #cn=admin,dc=ldap,dc=example,dc=be
+      pass: #ChangeMe
       searchFilter: (objectClass=*)
       userIdentityAttribute: cn
-  ingress:
-    enabled: false
-    hosts: []
+  # ---- ingress ----
+  traefikIngress:
+    enabled: true
+    host: nifi.test.local 
 
 openldap:
   enabled: true
   persistence:
-    enabled: false #true
+    enabled: #true
   env:
     LDAP_ORGANISATION: "Cetic"
     LDAP_DOMAIN: "ldap.cetic.be"
@@ -299,7 +308,7 @@ openldap:
     LDAP_TLS_ENFORCE: "false"
     LDAP_REMOVE_CONFIG_AFTER_SETUP: "false"
     LDAP_TLS_VERIFY_CLIENT: "try"
-  adminPassword: Z2JHHezi4aCC
+  adminPassword: password1
   configPassword: password2
   customLdifFiles:
     1-default-users.ldif: |-
@@ -307,7 +316,7 @@ openldap:
 
 
 phpldapadmin:
-  enabled: false
+  enabled: true
   service:
     type: ClusterIP
   env:
@@ -387,7 +396,7 @@ swaggerui:
       description: "TSIMULUS API"
 
 adminer:
-  enabled: false
+  enabled: true
   config:
     design: "pepa-linha"
   service:
@@ -557,7 +566,11 @@ influxdb:
     hostname: 
 
 traefik:
-  enabled: true
-  ingressRoute:
-    dashboard:
-      enabled: false
+  enabled: false
+  dashboardIngress:
+    enabled: true
+  dashboardHost: dashboard.test.local
+  # Uncomment these 2 lines below to access the dashboard through the ingness
+  # globalArguments:
+  #   - "--api.insecure=true"
+

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 # Declare variables to be passed into your templates.
 
 spark:
-  enabled: true
+  enabled: false
   Master:
     Name: spark-master
   WebUi:
@@ -16,11 +16,11 @@ spark:
     Replicas: 0
 
 superset:
-  enabled: true
+  enabled: false
   persistence:
     enabled: true
   service:
-    type: NodePort
+    type: ClusterIP
   configFile: |-
     from flask_appbuilder.security.manager import AUTH_DB,AUTH_LDAP
     #---------------------------------------------------------
@@ -60,7 +60,7 @@ superset:
     AUTH_LDAP_UID_FIELD = "cn"
 
 postgresql:
-  enabled: true
+  enabled: false
   persistence:
     enabled: true
   ldap:
@@ -135,17 +135,17 @@ postgresql:
       psql -c "create database zabbix;" postgres admin
 
 minio:
-  enabled: true
+  enabled: false
   persistence:
     enabled: true
     size: 50Gi
   service:
-    type: NodePort
+    type: ClusterIP
 
 grafana:
   enabled: true
   service:
-    type: NodePort
+    type: ClusterIP
   grafana.ini:
     paths:
       data: /var/lib/grafana/data
@@ -167,7 +167,7 @@ grafana:
       config_file: /etc/grafana/ldap.toml
   # Enable persistence
   persistence:
-    enabled: true
+    enabled: false
   # Administrator credentials when not using an existing secret (see below)
   adminUser: admin
 
@@ -177,7 +177,7 @@ grafana:
   ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
   ## ref: http://docs.grafana.org/installation/ldap/#configuration
   ldap:
-    enabled: true
+    enabled: false
     # `existingSecret` is a reference to an existing secret containing the ldap configuration
     # for Grafana in a key `ldap-toml`.
     existingSecret: ""
@@ -212,7 +212,7 @@ grafana:
       email =  "email"
 
 jupyterhub:
-  enabled: true
+  enabled: false
   proxy:
     secretToken: 'af83775ec3bfaf0507ce596df51d491e7ed54450adc454038fa7405495465f19'
     db:
@@ -261,25 +261,26 @@ jupyterhub:
 nifi:
   enabled: true
   service:
-    type: NodePort
+    type: ClusterIP
+    nodePort: ""
   postStart: /opt/nifi/psql; wget -P /opt/nifi/psql https://jdbc.postgresql.org/download/postgresql-42.2.6.jar
   persistence:
-    enabled: true
+    enabled: false
   properties:
     externalSecure: false
     isNode: true
     httpPort: 8080
-    httpsPort: null
-    webProxyHost:
+    httpsPort: 9443 #null
+    webProxyHost: nifi.test.local
     clusterPort: 6007
-    clusterSecure: false
+    clusterSecure: true #false
   auth:
     ldap:
-      enabled: false
-      host: ldap://<hostname>:<port>
-      searchBase: CN=Users,DC=example,DC=com
-      admin: cn=admin,dc=example,dc=be
-      pass: password
+      enabled: true
+      host: ldap://fadi-openldap:389 #ldap://<hostname>:<port>
+      searchBase: cn=admin,dc=ldap,dc=cetic,dc=be #CN=admin,DC=ldap,DC=example,DC=be
+      admin: cn=admin,dc=ldap,dc=cetic,dc=be #cn=admin,dc=ldap,dc=example,dc=be
+      pass: Z2JHHezi4aCC #ChangeMe
       searchFilter: (objectClass=*)
       userIdentityAttribute: cn
   ingress:
@@ -289,7 +290,7 @@ nifi:
 openldap:
   enabled: true
   persistence:
-    enabled: true
+    enabled: false #true
   env:
     LDAP_ORGANISATION: "Cetic"
     LDAP_DOMAIN: "ldap.cetic.be"
@@ -298,7 +299,7 @@ openldap:
     LDAP_TLS_ENFORCE: "false"
     LDAP_REMOVE_CONFIG_AFTER_SETUP: "false"
     LDAP_TLS_VERIFY_CLIENT: "try"
-  adminPassword: password1
+  adminPassword: Z2JHHezi4aCC
   configPassword: password2
   customLdifFiles:
     1-default-users.ldif: |-
@@ -306,9 +307,9 @@ openldap:
 
 
 phpldapadmin:
-  enabled: true
+  enabled: false
   service:
-    type: NodePort
+    type: ClusterIP
   env:
     PHPLDAPADMIN_LDAP_HOSTS: "fadi-openldap"
 
@@ -343,7 +344,7 @@ kibana:
 nginx_ldapauth_proxy:
   enabled: false
   service:
-    type: NodePort
+    type: ClusterIP
     externalPort: 5601
   proxy:
     port: 443
@@ -386,11 +387,11 @@ swaggerui:
       description: "TSIMULUS API"
 
 adminer:
-  enabled: true
+  enabled: false
   config:
     design: "pepa-linha"
   service:
-    type: NodePort
+    type: ClusterIP
 
 mlflow:
   enabled: false
@@ -452,7 +453,7 @@ airflow:
     port: 5432
     user: admin
   service:
-    type: NodePort
+    type: ClusterIP
     port: 8080
   auth:
     forcePassword: false
@@ -491,7 +492,7 @@ rabbitmq:
     tls:
       enabled: false
   service:
-    type: NodePort
+    type: ClusterIP
   ingress:
     enabled: false
     path: /
@@ -554,3 +555,9 @@ influxdb:
   ingress: 
     enabled: false
     hostname: 
+
+traefik:
+  enabled: true
+  ingressRoute:
+    dashboard:
+      enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,10 @@ superset:
     AUTH_LDAP_BIND_USER = "cn=admin,dc=ldap,dc=cetic,dc=be"
     AUTH_LDAP_BIND_PASSWORD = "password1"
     AUTH_LDAP_UID_FIELD = "cn"
+  # ---- ingress ----
+  traefikIngress:
+    enabled: true
+    host: superset.test.local
 
 postgresql:
   enabled: true
@@ -566,7 +570,7 @@ influxdb:
     hostname: 
 
 traefik:
-  enabled: false
+  enabled: true
   dashboardIngress:
     enabled: true
   dashboardHost: dashboard.test.local

--- a/values.yaml
+++ b/values.yaml
@@ -278,7 +278,7 @@ nifi:
     externalSecure: false
     isNode: true
     httpPort: 8080
-    httpsPort: #null
+    httpsPort: null
     webProxyHost: # set it by the same host than nifi.traefikIngress.host if traefik ingress is enabled
     clusterPort: 6007
     clusterSecure: false


### PR DESCRIPTION
- adding the traefik helm chart of Traefik in chart.yaml file: https://artifacthub.io/packages/helm/traefik/traefik
- Updating values.yaml file to integrate the values of Traefik
- adding an ingressroutes.yaml file for the ingress routes
- adding the ingresses for three services (Grafana, Nifi, Jupyterhub) and for the Traefik's dashboard